### PR TITLE
Ensured tr port is not removed

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -21,5 +21,5 @@ zopen_check_results()
 #
 zopen_post_install() 
 {
-  cd "$1" && find . -type f ! -name ".env" ! -name "install" ! -name "md5sum" ! -name "mktemp" -print | xargs rm
+   cd "$1" && find . -type f ! -name ".env" ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" -print | xargs rm 
 }


### PR DESCRIPTION
The issue https://github.com/ZOSOpenTools/libtoolport/issues/5 related to filename too long is fixed when we use tr from coreutils. Hence, it should not be removed.

I request @MikeFultonDev @IgorTodorovskiIBM to please review this.