### PR TITLE
fix for openat-proc and fdopendir which resulted in bad file descriptor

### DIFF
--- a/patches/PR7/PR7.patch
+++ b/patches/PR7/PR7.patch
@@ -34,7 +34,7 @@ index 3bacf7d..bb788fd 100644
 +    char dir[_XOPEN_PATH_MAX];
 +    int rc = w_ioctl(fd, _IOCC_GPN, _XOPEN_PATH_MAX, dir);
 +    if (rc == 0) {
-+      __e2a_l(dir, 1024);
++      __e2a_l(dir, _XOPEN_PATH_MAX);
 +    }
 +    size_t bufsize;
 +    dirlen = strlen (dir);

--- a/patches/PR7/PR7.patch
+++ b/patches/PR7/PR7.patch
@@ -1,0 +1,55 @@
+diff --git a/lib/fdopendir.c b/lib/fdopendir.c
+index c2b0e1e..82ae2e4 100644
+--- a/lib/fdopendir.c
++++ b/lib/fdopendir.c
+@@ -151,7 +151,9 @@ fdopendir_with_dup (int fd, int older_dupfd, struct saved_cwd const *cwd)
+         }
+       else
+         {
++#ifndef __MVS__
+           close (fd);
++#endif
+           dir = fd_clone_opendir (dupfd, cwd);
+           saved_errno = errno;
+           if (! dir)
+diff --git a/lib/openat-proc.c b/lib/openat-proc.c
+index 3bacf7d..bb788fd 100644
+--- a/lib/openat-proc.c
++++ b/lib/openat-proc.c
+@@ -28,6 +28,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <termios.h>
+ #include <unistd.h>
+ 
+ #ifdef __KLIBC__
+@@ -53,7 +54,27 @@ openat_proc_name (char buf[OPENAT_BUFFER_SIZE], int fd, char const *file)
+       return buf;
+     }
+ 
+-#ifndef __KLIBC__
++#ifdef __MVS__
++  {
++    char dir[_XOPEN_PATH_MAX];
++    int rc = w_ioctl(fd, _IOCC_GPN, _XOPEN_PATH_MAX, dir);
++    if (rc == 0) {
++      __e2a_l(dir, 1024);
++    }
++    size_t bufsize;
++    dirlen = strlen (dir);
++    bufsize = dirlen + 1 + strlen (file) + 1; /* 1 for '/', 1 for null */
++    if (OPENAT_BUFFER_SIZE < bufsize)
++      {
++        result = malloc (bufsize);
++        if (! result)
++          return NULL;
++      }
++
++    strcpy (result, dir);
++    result[dirlen++] = '/';
++  }
++#elif !defined( __KLIBC__)
+ # define PROC_SELF_FD_FORMAT "/proc/self/fd/%d/"
+   {
+     enum {


### PR DESCRIPTION
* Closing the file descriptor causes a bad file descriptor on z/OS
* We also needed a way to get the path name from a file descriptor, this implements it