### PR TITLE
add 'cp' command

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" -print | xargs rm 
 }


### PR DESCRIPTION
The 'cp -a' variant of cp is used in man-db for bootstrap