### PR TITLE
add od, cat, wc, date to list of commmands so that bash tests pass

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od"  -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc"  -print | xargs rm 
 }

--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od"  -print | xargs rm 
 }

--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc"  -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc" ! -name "date" -print | xargs rm 
 }


### PR DESCRIPTION
echo "" | od -t a prints the wrong value with the z/OS 'od' (prints lf instead of nl)