### PR TITLE
Install the touch command

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc" ! -name "date" ! -name "ptx" -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc" ! -name "date" ! -name "ptx" ! -name "touch" -print | xargs rm 
 }


### PR DESCRIPTION
We need touch for gettext because /bin/touch is created untagged files, which don't work well with git on z/OS.