### PR TITLE
Fix pinky + expose more core utils

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -43,5 +43,5 @@ ZZ
 
 zopen_post_install() 
 {
-   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha1sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc" ! -name "date" ! -name "ptx" ! -name "touch" -print | xargs rm 
+   cd "$1/bin" && find . -type f ! -name "install" ! -name "md5sum" ! -name "mktemp" ! -name "tr" ! -name "readlink" ! -name "realpath" ! -name "sha*sum" ! -name "fmt" ! -name "echo" ! -name "sort" ! -name "join" ! -name "cp" ! -name "od" ! -name "cat" ! -name "wc" ! -name "date" ! -name "ptx" ! -name "touch" ! -name "groups" ! -name "shred" ! -name "pinky" ! -name "numfmt" ! -name "vdir" ! -name "yes" -print | xargs rm 
 }

--- a/patches/PR1/zos_enablement.patch
+++ b/patches/PR1/zos_enablement.patch
@@ -67,59 +67,6 @@ index cfafb25..b0a5945 100644
                  {
                    intmax_t isize = size;
                    error (0, ftruncate_errno,
-diff --git a/src/pinky.c b/src/pinky.c
-index 88862c2..ef259ed 100644
---- a/src/pinky.c
-+++ b/src/pinky.c
-@@ -242,13 +242,21 @@ print_entry (const STRUCT_UTMP *utmp_ent)
-         printf (" %19s", _("        ???"));
-       else
-         {
-+#ifdef __MVS__
-+          char *const comma = "UNKNOWN";
-+#else
-           char *const comma = strchr (pw->pw_gecos, ',');
-+#endif
-           char *result;
- 
-           if (comma)
-             *comma = '\0';
- 
-+#ifdef __MVS__
-+          result = create_fullname ("", pw->pw_name);
-+#else
-           result = create_fullname (pw->pw_gecos, pw->pw_name);
-+#endif
-           printf (" %-19.19s", result);
-           free (result);
-         }
-@@ -323,13 +331,21 @@ print_long_entry (const char name[])
-     }
-   else
-     {
--      char *const comma = strchr (pw->pw_gecos, ',');
--      char *result;
-+#ifdef __MVS__
-+          char *const comma = "UNKNOWN";
-+#else
-+          char *const comma = strchr (pw->pw_gecos, ',');
-+#endif
-+          char *result;
- 
--      if (comma)
--        *comma = '\0';
-+          if (comma)
-+            *comma = '\0';
- 
--      result = create_fullname (pw->pw_gecos, pw->pw_name);
-+#ifdef __MVS__
-+          result = create_fullname ("", pw->pw_name);
-+#else
-+          result = create_fullname (pw->pw_gecos, pw->pw_name);
-+#endif
-       printf (" %s", result);
-       free (result);
-     }
 diff --git a/src/shred.c b/src/shred.c
 index 490fcd0..14e063e 100644
 --- a/src/shred.c

--- a/patches/pinky.c.patch
+++ b/patches/pinky.c.patch
@@ -1,0 +1,50 @@
+diff --git a/src/pinky.c b/src/pinky.c
+index 88862c2..39842df 100644
+--- a/src/pinky.c
++++ b/src/pinky.c
+@@ -242,13 +242,19 @@ print_entry (const STRUCT_UTMP *utmp_ent)
+         printf (" %19s", _("        ???"));
+       else
+         {
+-          char *const comma = strchr (pw->pw_gecos, ',');
+           char *result;
++#ifndef __MVS__
++          char *const comma = strchr (pw->pw_gecos, ',');
+ 
+           if (comma)
+             *comma = '\0';
++#endif
+ 
++#ifdef __MVS__
++          result = create_fullname ("", pw->pw_name);
++#else
+           result = create_fullname (pw->pw_gecos, pw->pw_name);
++#endif
+           printf (" %-19.19s", result);
+           free (result);
+         }
+@@ -323,13 +329,19 @@ print_long_entry (const char name[])
+     }
+   else
+     {
+-      char *const comma = strchr (pw->pw_gecos, ',');
+-      char *result;
++          char *result;
++#ifndef __MVS__
++          char *const comma = strchr (pw->pw_gecos, ',');
+ 
+-      if (comma)
+-        *comma = '\0';
++          if (comma)
++            *comma = '\0';
++#endif
+ 
+-      result = create_fullname (pw->pw_gecos, pw->pw_name);
++#ifdef __MVS__
++          result = create_fullname ("", pw->pw_name);
++#else
++          result = create_fullname (pw->pw_gecos, pw->pw_name);
++#endif
+       printf (" %s", result);
+       free (result);
+     }


### PR DESCRIPTION
* Expose more utilities that are not available in native z/OS such as groups, shred, pinky, numfmt, vdir, and yes
* Also fixes pinky's runtime crash
