### PR TITLE
Remove -fno-builtin

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -5,9 +5,9 @@ export ZOPEN_STABLE_URL="https://ftp.wayne.edu/gnu/coreutils/coreutils-9.1.tar.g
 export ZOPEN_STABLE_DEPS="make gzip tar curl perl automake autoconf m4 sed gettext zoslib diffutils"
 export ZOPEN_BOOTSTRAP="skip"
 export ZOPEN_EXTRA_CPPFLAGS="-DSLOW_BUT_NO_HACKS=1 -DNO_ASM -D_LARGE_TIME_API"
-export ZOPEN_EXTRA_CFLAGS="-fno-builtin"
 export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-dependency-tracking"
 export ZOPEN_CHECK_TIMEOUT=30000 # 8 hours and a bit
+
 zopen_check_results()
 {
 # Example check log file:


### PR DESCRIPTION
We narrowed down the bad builtins in comp_clang port anyway, -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc so this is redundant and not needed.