### PR TITLE
Exposed head tool - was used in shdoc

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -46,7 +46,7 @@ ZZ
 
 zopen_post_install() 
 {
-  export ZOPEN_COREUTILS="cat cp date echo fmt groups install join md5sum mkfifo mktemp numfmt od pinky ptx readlink realpath sha1sum sha224sum sha256sum sha384sum sha512sum shasum shred sort stat stdbuf touch tr vdir wc yes"
+  export ZOPEN_COREUTILS="cat cp date echo fmt groups head install join md5sum mkfifo mktemp numfmt od pinky ptx readlink realpath sha1sum sha224sum sha256sum sha384sum sha512sum shasum shred sort stat stdbuf touch tr vdir wc yes"
   findstring="find . -type f"
   for cmd in $ZOPEN_COREUTILS; do
     findstring="${findstring} ! -name ${cmd}"


### PR DESCRIPTION
In new tool - `shdoc` few test cases were failing due to use of `/bin/head`. On using this "`head`" , they passed. Hence, exposing this as part of installation