### PR TITLE
Update gnulib with fts fix for leaking open file descriptors - affecting chmod -R

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -52,7 +52,7 @@ zopen_pre_patch()
 
 zopen_post_install() 
 {
-  export ZOPEN_COREUTILS="b2sum base32 base64 basename blake2 cat chcon chgrp chmod chown chroot chksum comm cp csplit cut date dd df dir dircolors dirname du echo env expand expr factor false fmt groups head id install join ls md5sum mkfifo mktemp mknod nproc numfmt od pinky ptx readlink realpath sha1sum sha224sum sha256sum sha384sum sha512sum shasum stdbuf shred shuf sort stat stdbuf sync sleep touch tr tty vdir wc yes seq tac timeout truncate users"
+  export ZOPEN_COREUTILS="b2sum base32 base64 basename blake2 cat chcon chgrp chmod chown chroot chksum comm cp csplit cut date dd dir dircolors dirname du echo env expand expr factor false fmt groups head id install join ls md5sum mkfifo mktemp mknod nproc numfmt od pinky ptx readlink realpath sha1sum sha224sum sha256sum sha384sum sha512sum shasum stdbuf shred shuf sort stat stdbuf sync sleep touch tr tty vdir wc yes seq tac timeout truncate users"
   findstring="find . -type f"
   for cmd in $ZOPEN_COREUTILS; do
     findstring="${findstring} ! -name ${cmd}"

--- a/stable-patches/lib/fts.c.patch
+++ b/stable-patches/lib/fts.c.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/fts.c b/lib/fts.c
+index 5a86419..d99e666 100644
+--- a/lib/fts.c
++++ b/lib/fts.c
+@@ -1394,8 +1394,11 @@ fts_build (register FTS *sp, int type)
+                                  != NO_LEAF_OPTIMIZATION)));
+             if (descend || type == BREAD)
+               {
+-                if (ISSET(FTS_CWDFD))
++                if (ISSET(FTS_CWDFD)) {
++                  int old_fd = dir_fd;
+                   dir_fd = fcntl (dir_fd, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
++                  close(old_fd); // avoid lingering open file descriptors
++                }
+                 if (dir_fd < 0 || fts_safe_changedir(sp, cur, dir_fd, NULL)) {
+                         if (descend && type == BREAD)
+                                 cur->fts_errno = errno;

--- a/stable-patches/src/ls.c.patch
+++ b/stable-patches/src/ls.c.patch
@@ -1,0 +1,86 @@
+diff --git a/src/ls.c b/src/ls.c
+index f5ac98d..0f5cc72 100644
+--- a/src/ls.c
++++ b/src/ls.c
+@@ -115,6 +115,38 @@
+ #include "canonicalize.h"
+ #include "statx.h"
+ 
++#ifdef __MVS__
++#define MVS_LS "/bin/ls"
++#define MVS_LS_LEN (sizeof(MVS_ls)-1)
++#include <unistd.h>
++#include <sys/types.h>
++#include <sys/wait.h>
++
++extern char** environ;
++static bool
++do_mvs_ls (int argc, char **argv)
++{
++
++  pid_t pid = fork();
++  if (pid == 0) {
++    argv[0] = MVS_LS;
++    execvpe(MVS_LS, argv, environ);
++  } else if (pid > 0) {
++    int wstatus;
++    pid_t waitchild = waitpid(pid, &wstatus, WUNTRACED | WCONTINUED);
++    if (waitchild == -1) {
++      perror("waitpid");
++      return false;
++    }
++    if (WIFEXITED(wstatus)) {
++      return WEXITSTATUS(wstatus) == 0 ? true : false;
++    } else if (WIFSIGNALED(wstatus)) {
++      fprintf(stderr, "killed by signal %d\n", WTERMSIG(wstatus));
++    }
++  }
++}
++#endif
++
+ /* Include <sys/capability.h> last to avoid a clash of <sys/types.h>
+    include guards with some premature versions of libcap.
+    For more details, see <https://bugzilla.redhat.com/483548>.  */
+@@ -1926,7 +1958,7 @@ decode_switches (int argc, char **argv)
+     {
+       int oi = -1;
+       int c = getopt_long (argc, argv,
+-                           "abcdfghiklmnopqrstuvw:xABCDFGHI:LNQRST:UXZ1",
++                           "abcdEfghiklmnopqrstuvw:xABCDFGHI:LNQRST:UXZ1",
+                            long_options, &oi);
+       if (c == -1)
+         break;
+@@ -1949,6 +1981,15 @@ decode_switches (int argc, char **argv)
+           immediate_dirs = true;
+           break;
+ 
++#ifdef __MVS__
++        case 'E':
++        {
++            int ok = do_mvs_ls(argc, argv);
++            exit (ok ? EXIT_SUCCESS : EXIT_FAILURE);
++        }
++        break;
++#endif
++
+         case 'f':
+           ignore_mode = IGNORE_MINIMAL; /* enable -a */
+           sort_opt = sort_none;         /* enable -U */
+@@ -2110,9 +2151,17 @@ decode_switches (int argc, char **argv)
+           break;
+ 
+         case 'T':
++#ifdef __MVS__
++        {
++          int ok = do_mvs_ls(argc, argv);
++          exit (ok ? EXIT_SUCCESS : EXIT_FAILURE);
++        }
++          break;
++#else
+           tabsize_opt = xnumtoumax (optarg, 0, 0, MIN (PTRDIFF_MAX, SIZE_MAX),
+                                     "", _("invalid tab size"), LS_FAILURE);
+           break;
++#endif
+ 
+         case 'U':
+           sort_opt = sort_none;

--- a/stable-patches/src/od.c.patch
+++ b/stable-patches/src/od.c.patch
@@ -1,12 +1,13 @@
 diff --git a/src/od.c b/src/od.c
-index 3ad2565..b585be5 100644
+index d23df2c..986b6a5 100644
 --- a/src/od.c
 +++ b/src/od.c
-@@ -919,6 +919,10 @@ open_next_file (void)
+@@ -981,6 +981,11 @@ open_next_file (void)
      }
    while (in_stream == nullptr);
  
 +#ifdef __MVS__
++  if (!isatty(fileno(in_stream)))
 +  __disableautocvt(fileno(in_stream));
 +#endif
 +


### PR DESCRIPTION
* Also adds a bypass to /bin/ls if -T or -E are detected