### PR TITLE
Fix tag info truncated issue on ls -T and cat --help output formatting

### DIFF
--- a/stable-patches/src/cat.c.patch
+++ b/stable-patches/src/cat.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/cat.c b/src/cat.c
-index f9c9200..f6d5a66 100644
+index f9c9200..e84ea88 100644
 --- a/src/cat.c
 +++ b/src/cat.c
 @@ -39,6 +39,11 @@
@@ -14,23 +14,25 @@ index f9c9200..f6d5a66 100644
  /* The official name of this program (e.g., no 'g' prefix).  */
  #define PROGRAM_NAME "cat"
  
-@@ -126,6 +131,15 @@ Concatenate FILE(s) to standard output.\n\
+@@ -126,6 +131,17 @@ Concatenate FILE(s) to standard output.\n\
        oputs (_("\
    -v, --show-nonprinting   use ^ and M- notation, except for LFD and TAB\n\
  "));
 +#ifdef __MVS__
 +      oputs (_("\
-+  -B                      Disables the automatic conversion of tagged files.\n\
-+                          This option is ignored if the filecodeset or pgmcodeset options (-W option) are specified.\n\
++  -B                       Disables the automatic conversion of tagged files.\n\
++                           This option is ignored if the filecodeset or pgmcodeset options (-W option) are specified.\n\
++"));
++      oputs (_("\
 +  -W option[,option]...    Specifies z/OS-specific options. The option keywords are case-sensitive. Possible options are:\n\
-+                          filecodeset=codeset\n\
-+                          pgmcodeset=codeset\n\
++                           filecodeset=codeset\n\
++                           pgmcodeset=codeset\n\
 +"));
 +#endif
        oputs (HELP_OPTION_DESCRIPTION);
        oputs (VERSION_OPTION_DESCRIPTION);
        printf (_("\
-@@ -140,6 +154,137 @@ Examples:\n\
+@@ -140,6 +156,137 @@ Examples:\n\
    exit (status);
  }
  
@@ -168,7 +170,7 @@ index f9c9200..f6d5a66 100644
  /* Compute the next line number.  */
  
  static void
-@@ -545,6 +690,35 @@ copy_cat (void)
+@@ -545,6 +692,35 @@ copy_cat (void)
        }
  }
  
@@ -204,7 +206,7 @@ index f9c9200..f6d5a66 100644
  
  int
  main (int argc, char **argv)
-@@ -561,6 +735,10 @@ main (int argc, char **argv)
+@@ -561,6 +737,10 @@ main (int argc, char **argv)
    bool show_ends = false;
    bool show_nonprinting = false;
    bool show_tabs = false;
@@ -215,7 +217,7 @@ index f9c9200..f6d5a66 100644
    int file_open_mode = O_RDONLY;
  
    static struct option const long_options[] =
-@@ -577,6 +755,19 @@ main (int argc, char **argv)
+@@ -577,6 +757,19 @@ main (int argc, char **argv)
      {NULL, 0, NULL, 0}
    };
  
@@ -235,7 +237,7 @@ index f9c9200..f6d5a66 100644
    initialize_main (&argc, &argv);
    set_program_name (argv[0]);
    setlocale (LC_ALL, "");
-@@ -592,8 +783,13 @@ main (int argc, char **argv)
+@@ -592,8 +785,13 @@ main (int argc, char **argv)
    /* Parse command line options.  */
  
    int c;
@@ -249,7 +251,7 @@ index f9c9200..f6d5a66 100644
      {
        switch (c)
          {
-@@ -642,6 +838,22 @@ main (int argc, char **argv)
+@@ -642,6 +840,22 @@ main (int argc, char **argv)
            show_tabs = true;
            break;
  
@@ -272,7 +274,7 @@ index f9c9200..f6d5a66 100644
          case_GETOPT_HELP_CHAR;
  
          case_GETOPT_VERSION_CHAR (PROGRAM_NAME, AUTHORS);
-@@ -651,6 +863,19 @@ main (int argc, char **argv)
+@@ -651,6 +865,19 @@ main (int argc, char **argv)
          }
      }
  
@@ -292,7 +294,7 @@ index f9c9200..f6d5a66 100644
    /* Get device, i-node number, and optimal blocksize of output.  */
  
    if (fstat (STDOUT_FILENO, &ostat_buf) < 0)
-@@ -702,6 +927,19 @@ main (int argc, char **argv)
+@@ -702,6 +929,19 @@ main (int argc, char **argv)
              }
          }
  

--- a/stable-patches/src/ls.c.patch
+++ b/stable-patches/src/ls.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/ls.c b/src/ls.c
-index 70ddba1..741a1a3 100644
+index 70ddba1..d6a9fb7 100644
 --- a/src/ls.c
 +++ b/src/ls.c
 @@ -59,6 +59,10 @@
@@ -114,7 +114,7 @@ index 70ddba1..741a1a3 100644
 +   struct stat *sb = NULL;
 +   char txtflag[6] = "     ";
 +   char filetype[2] = " ";
-+   char buf[_CSNAME_LEN_MAX + sizeof(txtflag) + sizeof(filetype) + 2];
++   static char buf[_CSNAME_LEN_MAX + sizeof(txtflag) + sizeof(filetype) + 2];
 +   sb = &f->stat;
 +   if ((f->filetype != directory) && (f->filetype != symbolic_link)) {
 +      __toCSName(sb->st_tag.ft_ccsid, filetag);
@@ -147,16 +147,24 @@ index 70ddba1..741a1a3 100644
  
  /* Print information about F in long format.  */
  static void
-@@ -4238,7 +4327,7 @@ print_long_format (const struct fileinfo *f)
+@@ -4238,9 +4327,15 @@ print_long_format (const struct fileinfo *f)
  {
    char modebuf[12];
    char buf
 -    [LONGEST_HUMAN_READABLE + 1		/* inode */
 +    [LONGEST_HUMAN_READABLE + 1        /* inode */
       + LONGEST_HUMAN_READABLE + 1	/* size in blocks */
++#ifdef __MVS__
++     + _CSNAME_LEN_MAX + 10             /* tag */
++#endif
       + sizeof (modebuf) - 1 + 1		/* mode string */
++#ifdef __MVS__
++     + 10                               /* extended_attributes */
++#endif
       + INT_BUFSIZE_BOUND (uintmax_t)	/* st_nlink */
-@@ -4251,7 +4340,6 @@ print_long_format (const struct fileinfo *f)
+      + LONGEST_HUMAN_READABLE + 2	/* major device number */
+      + LONGEST_HUMAN_READABLE + 1	/* minor device number */
+@@ -4251,7 +4346,6 @@ print_long_format (const struct fileinfo *f)
    struct timespec when_timespec;
    struct tm when_local;
    bool btime_ok = true;
@@ -164,7 +172,7 @@ index 70ddba1..741a1a3 100644
    /* Compute the mode string, except remove the trailing space if no
       file in this directory has an ACL or security context.  */
    if (f->stat_ok)
-@@ -4292,7 +4380,6 @@ print_long_format (const struct fileinfo *f)
+@@ -4292,7 +4386,6 @@ print_long_format (const struct fileinfo *f)
      }
  
    p = buf;
@@ -172,7 +180,7 @@ index 70ddba1..741a1a3 100644
    if (print_inode)
      {
        char hbuf[INT_BUFSIZE_BOUND (uintmax_t)];
-@@ -4316,11 +4403,25 @@ print_long_format (const struct fileinfo *f)
+@@ -4316,11 +4409,25 @@ print_long_format (const struct fileinfo *f)
        p[-1] = ' ';
      }
  


### PR DESCRIPTION
Fix tag info truncated issue on ls -T and cat --help output formatting