### PR TITLE
Add included utils list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Use the zopen package manager ([QuickStart Guide](https://zopen.community/#/Guid
 zopen install coreutils
 ```
 
+This z/OS port currently ships the following subset of GNU coreutils commands.
+This list mirrors the commands retained by the `ZOPEN_COREUTILS` allowlist in `buildenv`.
+```text
+b2sum base32 base64 basename blake2 cat chcon chgrp chmod chown chroot chksum
+comm cp csplit cut date dd dir dircolors dirname df du echo env expand expr
+factor false fmt groups head id install join ls md5sum mkfifo mktemp mknod
+nproc numfmt od pinky printf printenv ptx readlink realpath sha1sum sha224sum
+sha256sum sha384sum sha512sum shasum stdbuf shred shuf sort stat sync sleep
+touch tr tty vdir wc yes seq tac timeout truncate users
+```
+
 # Building from Source
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ zopen install coreutils
 ```
 
 This z/OS port currently ships the following subset of GNU coreutils commands.
-This list mirrors the commands retained by the `ZOPEN_COREUTILS` allowlist in `buildenv`.
+By default, the installed commands are available with a `g` prefix to avoid
+collisions with z/OS `/bin` tools, for example `cp` as `gcp` and `ls` as `gls`.
+This list mirrors the commands retained by the `ZOPEN_COREUTILS` allowlist in
+`buildenv`.
 ```text
 b2sum base32 base64 basename blake2 cat chcon chgrp chmod chown chroot chksum
 comm cp csplit cut date dd dir dircolors dirname df du echo env expand expr


### PR DESCRIPTION
Document the subset of coreutils commands currently shipped by this port and note the default `g` command prefix used after install.

The list mirrors the `ZOPEN_COREUTILS` allowlist in `buildenv`.

Fixes #92.